### PR TITLE
DE-351: Allow query strings in the url

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -15,7 +15,7 @@
 
 define( 'AMP__FILE__', __FILE__ );
 define( 'AMP__DIR__', dirname( __FILE__ ) );
-define( 'AMP__VERSION', '1.5.0.1-alpha' );
+define( 'AMP__VERSION', '1.5.0.2-alpha' );
 
 /**
  * Errors encountered while loading the plugin.

--- a/assets/js/amp-wp-app-shell.js
+++ b/assets/js/amp-wp-app-shell.js
@@ -183,18 +183,23 @@
 
 				// @todo If it is not an AMP document, then the loaded document needs to break out of the app shell. This should be done in readChunk() below.
 				currentShadowDoc.ampdoc.whenReady().then( () => {
-					let currentUrl;
-					if ( currentShadowDoc.canonicalUrl ) {
-						currentUrl = new URL( currentShadowDoc.canonicalUrl );
+					let currentUrl new URL( url );
 
-						// Prevent updating the URL if the canonical URL is for the error template.
-						// @todo The rel=canonical link should not be output for these templates.
-						if ( currentUrl.searchParams.has( 'wp_error_template' ) ) {
-							currentUrl = currentUrl.href = url;
-						}
-					} else {
-						currentUrl = new URL( url );
-					}
+					// Toby - 17/4/20
+					// Removed to allow querystring params in the URL
+					// https://github.com/ampproject/amp-wp/issues/4376
+					//
+					// if ( currentShadowDoc.canonicalUrl ) {
+					// 	currentUrl = new URL( currentShadowDoc.canonicalUrl );
+
+					// 	// Prevent updating the URL if the canonical URL is for the error template.
+					// 	// @todo The rel=canonical link should not be output for these templates.
+					// 	if ( currentUrl.searchParams.has( 'wp_error_template' ) ) {
+					// 		currentUrl = currentUrl.href = url;
+					// 	}
+					// } else {
+					// 	currentUrl = new URL( url );
+					// }
 
 					// Update the nav menu classes if the final URL has redirected somewhere else.
 					if ( currentUrl.toString() !== url.toString() ) {

--- a/assets/js/amp-wp-app-shell.js
+++ b/assets/js/amp-wp-app-shell.js
@@ -183,7 +183,7 @@
 
 				// @todo If it is not an AMP document, then the loaded document needs to break out of the app shell. This should be done in readChunk() below.
 				currentShadowDoc.ampdoc.whenReady().then( () => {
-					let currentUrl new URL( url );
+					let currentUrl = new URL( url );
 
 					// Toby - 17/4/20
 					// Removed to allow querystring params in the URL


### PR DESCRIPTION
Fixes: https://novaent.atlassian.net/browse/DE-351

As per discussion here: https://github.com/ampproject/amp-wp/issues/4376

Allows for query params to be persisted in the url.