### PR TITLE
Remove custom document output filter

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -2077,7 +2077,7 @@ class AMP_Theme_Support {
 	 */
 	public static function finish_output_buffering( $response ) {
 		self::$is_output_buffering = false;
-		return apply_filters( 'nova_amp_document_output', self::prepare_response( $response ) );
+		return self::prepare_response( $response );
 	}
 
 	/**


### PR DESCRIPTION
Some features (like Wayin embeds) do not generate valid AMP markup and get removed by the AMP sanitizer. Since those features are still needed, a custom filter has been introduced to this fork of `amp-wp` plugin.

A different approach has been proposed in novaueng/wp-platform#22 which makes this custom filter redundant. Thanks to that, the NOVA's fork will get one step closer to the official `amp-wp` plugin implementation.

Please note that this should be deployed at the same time or _after_ novaueng/wp-platform#22 is deployed.

## Summary

<!-- Please reference the issue this PR addresses. -->
Fixes n/a
